### PR TITLE
add version to v1 - freezing on current behavior (latest 2.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This action is only available for Linux and macOS [virtual environments](https:/
 
 ## Usage
 
-Just uses `kool-dev/action@v1` at your action yml file. e.g:
+Just use `kool-dev/action@v1` at your action YAML configuration file:
 
 ```yml
 on: [push, workflow_dispatch]
@@ -23,6 +23,6 @@ jobs:
     steps:
       - uses: kool-dev/action@v1
 
-      - name: Checking kool.dev version
+      - name: Checking kool.dev Version
         run: kool --version
 ```

--- a/action.yml
+++ b/action.yml
@@ -4,7 +4,7 @@ description: 'Install Kool CLI'
 runs:
   using: "composite"
   steps:
-    - run: curl -fsSL https://raw.githubusercontent.com/kool-dev/kool/master/install.sh | sudo bash
+    - run: curl -fsSL "https://kool.dev/install?v=2&source=action" | bash
       shell: bash
 
 branding:


### PR DESCRIPTION
Going to tag 1.x to freeze installation with current behavior - downloading latest version as of today, in preparation for next major release v3.